### PR TITLE
removed block to append query params to already fully formatted url. …

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -135,9 +135,6 @@ func (c *Client) Connect() error {
 				}
 
 				requestURI := fmt.Sprintf("%s%s", proxyHost, req.URL.String())
-				if len(req.URL.RawQuery) > 0 {
-					requestURI = requestURI + "?" + req.URL.RawQuery
-				}
 
 				log.Printf("[%s] proxy => %s", inletsID, requestURI)
 


### PR DESCRIPTION
…This was causing duplication in GET params: ?foo=bar was: ?foo=bar?foo=bar

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
